### PR TITLE
Set ops/dev env urls

### DIFF
--- a/dps_info/package.json
+++ b/dps_info/package.json
@@ -34,7 +34,6 @@
     "@phosphor/widgets": "^1.8.1",
     "@types/jquery": "^3.3.29",
     "@types/node": "^11.11.5",
-    "@types/react-treeview": "^0.4.2",
     "jquery": "^3.3.1",
     "jupyterlab_toastify": "^2.3.0",
     "require": "^2.4.20",

--- a/dps_magic/dps_magic/hysds.py
+++ b/dps_magic/dps_magic/hysds.py
@@ -7,8 +7,12 @@ from IPython.display import display, HTML
 
 logger = logging.getLogger()
 # logger.setLevel(logging.DEBUG)
-# CHE_BASE_URL = 'https://che-k8s.maap.xyz'
-CHE_BASE_URL = 'https://ade.maap-project.org'
+
+# set base url based on ops/dev environment
+CHE_BASE_URL = "https://che-k8s.maap.xyz"
+if 'ENVIRONMENT' in os.environ.keys() and os.environ['ENVIRONMENT'] == 'OPS':
+    CHE_BASE_URL = "https://ade.maap-project.org"
+
 
 @magics_class
 class HysdsMagic(Magics):

--- a/edsc_extension/package.json
+++ b/edsc_extension/package.json
@@ -36,6 +36,7 @@
     "@jupyterlab/mainmenu": "^1.0.1",
     "@jupyterlab/notebook": "^1.0.1",
     "@types/jquery": "^3.3.30",
+    "@types/node": "^13.11.1",
     "jquery": "^3.4.1",
     "jupyterlab_toastify": "^2.3.0"
   },

--- a/edsc_extension/src/index.ts
+++ b/edsc_extension/src/index.ts
@@ -23,7 +23,8 @@ import { IFrameWidget } from './widgets';
 import { setResultsLimit, displaySearchParams } from './popups'
 import globals = require("./globals");
 
-const SEARCH_CLIENT_URL = "https://ade.maap-project.org:3052/search";
+//const SEARCH_CLIENT_URL = "https://ade.maap-project.org:3052/search";
+const SEARCH_CLIENT_URL = "https://che-k8s.maap.xyz:3052/search";
 
 ///////////////////////////////////////////////////////////////
 //

--- a/edsc_extension/src/index.ts
+++ b/edsc_extension/src/index.ts
@@ -23,8 +23,11 @@ import { IFrameWidget } from './widgets';
 import { setResultsLimit, displaySearchParams } from './popups'
 import globals = require("./globals");
 
-//const SEARCH_CLIENT_URL = "https://ade.maap-project.org:3052/search";
 const SEARCH_CLIENT_URL = "https://che-k8s.maap.xyz:3052/search";
+if (process.env.ENVIRONMENT == 'OPS') {
+  SEARCH_CLIENT_URL = "https://ade.maap-project.org:3052/search";
+}
+console.log(SEARCH_CLIENT_URL);
 
 ///////////////////////////////////////////////////////////////
 //

--- a/edsc_extension/src/index.ts
+++ b/edsc_extension/src/index.ts
@@ -23,7 +23,7 @@ import { IFrameWidget } from './widgets';
 import { setResultsLimit, displaySearchParams } from './popups'
 import globals = require("./globals");
 
-const SEARCH_CLIENT_URL = "https://che-k8s.maap.xyz:3052/search";
+var SEARCH_CLIENT_URL = "https://che-k8s.maap.xyz:3052/search";
 if (process.env.ENVIRONMENT == 'OPS') {
   SEARCH_CLIENT_URL = "https://ade.maap-project.org:3052/search";
 }

--- a/edsc_extension/tsconfig.json
+++ b/edsc_extension/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "compilerOptions": {
-    //"declaration": true,
-    "allowJs": true,
-    "allowSyntheticDefaultImports": true,
-    "lib": ["es2015", "dom", "ES5", "ES2015.Promise", "DOM", "es6"],
+    "lib": ["es2015", "dom","es2017"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,
@@ -12,8 +9,12 @@
     "rootDir": "src",
     "strict": true,
     "strictNullChecks": false,
-    "target": "es2015",
-    "types": ["node"]
+    "target": "ES6",
+    "types": ["node"],
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "noImplicitAny": false,
   },
   "include": ["src/*"]
 }

--- a/edsc_extension/tsconfig.json
+++ b/edsc_extension/tsconfig.json
@@ -13,7 +13,7 @@
     "strict": true,
     "strictNullChecks": false,
     "target": "es2015",
-    "types": []
+    "types": ["node"]
   },
   "include": ["src/*"]
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,4 +28,8 @@ env | grep _ >> /etc/environment
 # Add conda bin to path
 export PATH=$PATH:/opt/conda/bin
 
+# in show_ssh_info extension we inject user's keys to authorized keys file under the root dir
+# by default sshd looks in the home dir which is /projects - must direct sshd to look at /root
+echo "AuthorizedKeysFile  /root/.ssh/authorized_keys" >> /etc/ssh/sshd_config &&  service ssh restart
+
 jupyter lab --ip=0.0.0.0 --port=3100 --allow-root --NotebookApp.token='' --LabApp.base_url=$PREVIEW_URL --no-browser --debug

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,8 +28,4 @@ env | grep _ >> /etc/environment
 # Add conda bin to path
 export PATH=$PATH:/opt/conda/bin
 
-# in show_ssh_info extension we inject user's keys to authorized keys file under the root dir
-# by default sshd looks in the home dir which is /projects - must direct sshd to look at /root
-echo "AuthorizedKeysFile  /root/.ssh/authorized_keys" >> /etc/ssh/sshd_config &&  service ssh restart
-
 jupyter lab --ip=0.0.0.0 --port=3100 --allow-root --NotebookApp.token='' --LabApp.base_url=$PREVIEW_URL --no-browser --debug

--- a/pull_projects/pull_projects/handlers.py
+++ b/pull_projects/pull_projects/handlers.py
@@ -11,8 +11,15 @@ from git import Repo
 import shutil
 import urllib
 
-# GITLAB_REPO = "mas.maap-project.org"
+# set base url based on ops/dev environment
 GITLAB_REPO = "repo.nasa.maap.xyz"
+if 'ENVIRONMENT' in os.environ.keys() and os.environ['ENVIRONMENT'] == 'OPS':
+    GITLAB_REPO = "mas.maap-project.org"
+
+CHE_BASE_URL = "https://che-k8s.maap.xyz"
+if 'ENVIRONMENT' in os.environ.keys() and os.environ['ENVIRONMENT'] == 'OPS':
+    CHE_BASE_URL = "https://ade.maap-project.org"
+
 
 # Set selected ADE Docker Image 
 class ListProjectsHandler(IPythonHandler):
@@ -20,8 +27,7 @@ class ListProjectsHandler(IPythonHandler):
         # 'https://ade.maap-project.org/api/workspace/workspacetn41o4yl4a7kxclz'
         workspace_id = os.environ['CHE_WORKSPACE_ID']
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        # url = 'https://ade.maap-project.org/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
-        url = 'https://che-k8s.maap.xyz/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
+        url = '{base_url}/api/workspace/{workspace_id}'.format(base_url=CHE_BASE_URL,workspace_id=workspace_id)
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------
@@ -56,8 +62,7 @@ class ListFilesHandler(IPythonHandler):
         # 'https://ade.maap-project.org/api/workspace/workspacetn41o4yl4a7kxclz'
         workspace_id = os.environ['CHE_WORKSPACE_ID']
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        # url = 'https://ade.maap-project.org/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
-        url = 'https://che-k8s.maap.xyz/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
+        url = '{base_url}/api/workspace/{workspace_id}'.format(base_url=CHE_BASE_URL,workspace_id=workspace_id)
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------
@@ -131,8 +136,7 @@ class GetAllProjectsHandler(IPythonHandler):
         # --------------------------------------------------
         workspace_id = os.environ['CHE_WORKSPACE_ID']
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        # url = 'https://ade.maap-project.org/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
-        url = 'https://che-k8s.maap.xyz/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
+        url = '{base_url}/api/workspace/{workspace_id}'.format(base_url=CHE_BASE_URL,workspace_id=workspace_id)
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------

--- a/pull_projects/pull_projects/handlers.py
+++ b/pull_projects/pull_projects/handlers.py
@@ -11,7 +11,8 @@ from git import Repo
 import shutil
 import urllib
 
-GITLAB_REPO = "mas.maap-project.org"
+# GITLAB_REPO = "mas.maap-project.org"
+GITLAB_REPO = "repo.nasa.maap.xyz"
 
 # Set selected ADE Docker Image 
 class ListProjectsHandler(IPythonHandler):
@@ -19,7 +20,8 @@ class ListProjectsHandler(IPythonHandler):
         # 'https://ade.maap-project.org/api/workspace/workspacetn41o4yl4a7kxclz'
         workspace_id = os.environ['CHE_WORKSPACE_ID']
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        url = 'https://ade.maap-project.org/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
+        # url = 'https://ade.maap-project.org/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
+        url = 'https://che-k8s.maap.xyz/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------
@@ -54,7 +56,8 @@ class ListFilesHandler(IPythonHandler):
         # 'https://ade.maap-project.org/api/workspace/workspacetn41o4yl4a7kxclz'
         workspace_id = os.environ['CHE_WORKSPACE_ID']
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        url = 'https://ade.maap-project.org/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
+        # url = 'https://ade.maap-project.org/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
+        url = 'https://che-k8s.maap.xyz/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------
@@ -128,7 +131,8 @@ class GetAllProjectsHandler(IPythonHandler):
         # --------------------------------------------------
         workspace_id = os.environ['CHE_WORKSPACE_ID']
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        url = 'https://ade.maap-project.org/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
+        # url = 'https://ade.maap-project.org/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
+        url = 'https://che-k8s.maap.xyz/api/workspace/{workspace_id}'.format(workspace_id=workspace_id)
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------

--- a/show_ssh_info/show_ssh_info/handlers.py
+++ b/show_ssh_info/show_ssh_info/handlers.py
@@ -103,8 +103,8 @@ class CheckInstallersHandler(IPythonHandler):
         # self.finish({'status': True})
 
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        # url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
-        url = 'https://che-k8s.maap.xyz/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
+        url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
+        # url = 'https://che-k8s.maap.xyz/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------
@@ -134,8 +134,8 @@ class InstallHandler(IPythonHandler):
     def get(self):
 
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        # url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
-        url = 'https://che-k8s.maap.xyz/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
+        url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
+        # url = 'https://che-k8s.maap.xyz/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------
@@ -250,8 +250,8 @@ class MountOrgBucketsHandler(IPythonHandler):
         # ts pass keycloak token from window
         token = self.get_argument('token','')
         bucket = self.get_argument('bucket','')
-        # url = 'https://ade.maap-project.org/api/organization'
-        url = 'https://che-k8s.maap.xyz/api/organization'
+        url = 'https://ade.maap-project.org/api/organization'
+        # url = 'https://che-k8s.maap.xyz/api/organization'
         
         headers = {
             'Accept':'application/json',

--- a/show_ssh_info/show_ssh_info/handlers.py
+++ b/show_ssh_info/show_ssh_info/handlers.py
@@ -24,7 +24,7 @@ class InjectKeyHandler(IPythonHandler):
         print("=== Injecting SSH KEY ===")
 
         # Check if .ssh directory exists, if not create it
-        os.chdir('/root')
+        os.chdir('/projects')
         if not os.path.exists(".ssh"):
             os.makedirs(".ssh")
 
@@ -48,10 +48,9 @@ class InjectKeyHandler(IPythonHandler):
             cmd = "echo " + public_key + " >> .ssh/authorized_keys && chmod 700 /projects && chmod 700 .ssh/ && chmod 600 .ssh/authorized_keys"
             print(cmd)
             subprocess.check_output(cmd, shell=True)
-            os.chdir('/projects')
+            print("=== INJECTED KEY ===")
         else:
-            os.chdir('/projects')
-            print("====== SUCCESS ========")
+            print("=== KEY ALREADY PRESENT ===")
 
         print("=== Checking for existence of MAAP_PGT ===")
 

--- a/show_ssh_info/show_ssh_info/handlers.py
+++ b/show_ssh_info/show_ssh_info/handlers.py
@@ -103,7 +103,8 @@ class CheckInstallersHandler(IPythonHandler):
         # self.finish({'status': True})
 
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
+        # url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
+        url = 'https://che-k8s.maap.xyz/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------
@@ -133,7 +134,8 @@ class InstallHandler(IPythonHandler):
     def get(self):
 
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
+        # url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
+        url = 'https://che-k8s.maap.xyz/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------
@@ -152,8 +154,6 @@ class InstallHandler(IPythonHandler):
 
         # Update workspace config with new installers
         workspace_config['config']['environments']["default"]["machines"]["ws/jupyter"]['installers'] = installers
-
-        put_url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
 
         r = requests.put(
             url,
@@ -250,7 +250,9 @@ class MountOrgBucketsHandler(IPythonHandler):
         # ts pass keycloak token from window
         token = self.get_argument('token','')
         bucket = self.get_argument('bucket','')
-        url = 'https://ade.maap-project.org/api/organization'
+        # url = 'https://ade.maap-project.org/api/organization'
+        url = 'https://che-k8s.maap.xyz/api/organization'
+        
         headers = {
             'Accept':'application/json',
             'Authorization':'Bearer {token}'.format(token=token)

--- a/show_ssh_info/show_ssh_info/handlers.py
+++ b/show_ssh_info/show_ssh_info/handlers.py
@@ -19,7 +19,7 @@ class InjectKeyHandler(IPythonHandler):
         print("=== Injecting SSH KEY ===")
 
         # Check if .ssh directory exists, if not create it
-        os.chdir('/root')
+        os.chdir('/projects')
         if not os.path.exists(".ssh"):
             os.makedirs(".ssh")
 

--- a/show_ssh_info/show_ssh_info/handlers.py
+++ b/show_ssh_info/show_ssh_info/handlers.py
@@ -218,13 +218,13 @@ class MountBucketHandler(IPythonHandler):
                 if not os.path.exists('{}/{}'.format(user_workspace,username)):
                     os.mkdir('{}/{}'.format(user_workspace,username))
 
-                if not os.path.exists('{}/{}/dps_output'.format(user_workspace,username)):
-                    os.mkdir('{}/{}/dps_output'.format(user_workspace,username))
-
                 # make sure folder permissions are at least 755
-                chmod_output = subprocess.check_output('chmod 755 {path}/{username}').format(path=user_workspace,username=username)
+                chmod_output = subprocess.check_output('chmod 755 {path}/{username}'.format(path=user_workspace,username=username), shell=True).decode('utf-8')
                 message = chmod_output
                 logging.debug('chmod output {}'.format(chmod_output))
+
+                if not os.path.exists('{}/{}/dps_output'.format(user_workspace,username)):
+                    os.mkdir('{}/{}/dps_output'.format(user_workspace,username))
 
                 # touch & rm file to register folder to filesystem
                 touch_output = subprocess.check_output('touch {path}/{username}/dps_output/testfile && rm {path}/{username}/dps_output/testfile'.format(path=user_workspace,username=username), shell=True).decode('utf-8')

--- a/show_ssh_info/show_ssh_info/handlers.py
+++ b/show_ssh_info/show_ssh_info/handlers.py
@@ -11,6 +11,11 @@ import logging
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
+# set base url based on ops/dev environment
+CHE_BASE_URL = "https://che-k8s.maap.xyz"
+if 'ENVIRONMENT' in os.environ.keys() and os.environ['ENVIRONMENT'] == 'OPS':
+    CHE_BASE_URL = "https://ade.maap-project.org"
+
 
 class InjectKeyHandler(IPythonHandler):
     def get(self):
@@ -19,7 +24,7 @@ class InjectKeyHandler(IPythonHandler):
         print("=== Injecting SSH KEY ===")
 
         # Check if .ssh directory exists, if not create it
-        os.chdir('/projects')
+        os.chdir('/root')
         if not os.path.exists(".ssh"):
             os.makedirs(".ssh")
 
@@ -103,8 +108,7 @@ class CheckInstallersHandler(IPythonHandler):
         # self.finish({'status': True})
 
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
-        # url = 'https://che-k8s.maap.xyz/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
+        url = '{}/api/workspace/{}'.format(CHE_BASE_URL,os.environ.get('CHE_WORKSPACE_ID'))
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------
@@ -134,8 +138,7 @@ class InstallHandler(IPythonHandler):
     def get(self):
 
         che_machine_token = os.environ['CHE_MACHINE_TOKEN']
-        url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
-        # url = 'https://che-k8s.maap.xyz/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
+        url = '{}/api/workspace/{}'.format(CHE_BASE_URL,os.environ.get('CHE_WORKSPACE_ID'))
         # --------------------------------------------------
         # TODO: FIGURE OUT AUTH KEY & verify
         # --------------------------------------------------
@@ -154,6 +157,8 @@ class InstallHandler(IPythonHandler):
 
         # Update workspace config with new installers
         workspace_config['config']['environments']["default"]["machines"]["ws/jupyter"]['installers'] = installers
+
+        put_url = 'https://ade.maap-project.org/api/workspace/' + os.environ.get('CHE_WORKSPACE_ID')
 
         r = requests.put(
             url,
@@ -250,9 +255,7 @@ class MountOrgBucketsHandler(IPythonHandler):
         # ts pass keycloak token from window
         token = self.get_argument('token','')
         bucket = self.get_argument('bucket','')
-        url = 'https://ade.maap-project.org/api/organization'
-        # url = 'https://che-k8s.maap.xyz/api/organization'
-        
+        url = '{}/api/organization'.format(CHE_BASE_URL)
         headers = {
             'Accept':'application/json',
             'Authorization':'Bearer {token}'.format(token=token)

--- a/show_ssh_info/src/widgets.ts
+++ b/show_ssh_info/src/widgets.ts
@@ -65,7 +65,7 @@ export class InjectSSH {
     getUserInfo(function(profile: any) {
 
         if (profile['public_ssh_keys'] === undefined) {
-            INotification.error("Injecting user's SSH key failed - SSH Key undefined.");
+            INotification.warning("User's SSH Key undefined. SSH service unavailable.");
             return;
         }
         let key = profile['public_ssh_keys'];
@@ -80,7 +80,7 @@ export class InjectSSH {
         // Make call to back end
         let xhr = new XMLHttpRequest();
         xhr.onload = function() {
-            console.log("SSH Key injected");
+            console.log("Checked for/injected user's public key");
         };
         xhr.open("GET", getUrl.href, true);
         xhr.send(null);

--- a/submit_jobs/package.json
+++ b/submit_jobs/package.json
@@ -34,7 +34,6 @@
     "@phosphor/widgets": "^1.8.1",
     "@types/jquery": "^3.3.29",
     "@types/node": "^11.11.5",
-    "@types/react-treeview": "^0.4.2",
     "jquery": "^3.3.1",
     "jupyterlab_toastify": "^2.3.0",
     "require": "^2.4.20",

--- a/submit_jobs/requirements.txt
+++ b/submit_jobs/requirements.txt
@@ -1,1 +1,2 @@
 jupyterlab
+pyyaml

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -21,8 +21,11 @@ WORKDIR = FILEPATH+'/..'
 sys.path.append(WORKDIR)
 # USE https when pointing to actual MAAP API server
 #BASE_URL = "http://localhost:5000/api"
+
+# set base url based on ops/dev environment
 BASE_URL = "https://api.maap.xyz/api"
-# BASE_URL = "https://api.maap-project.org/api"
+if 'ENVIRONMENT' in os.environ.keys() and os.environ['ENVIRONMENT'] == 'OPS':
+    BASE_URL = "https://api.maap-project.org/api"
 
 
 # helper to parse out algorithm parameters for execute, describe


### PR DESCRIPTION
Update URLS based on ops/dev environment

Uses environment variable ENVIRONMENT to determine which set of urls to point to. This simplifies having the dev/ops environments have to hit different services. Previously - urls had to be manually changed and this was messy.

(#53 but only relevant commits 5dd66ee)