### PR TITLE
Use maap-py for MAAP API

### DIFF
--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -996,6 +996,8 @@ class DeleteHandler(IPythonHandler):
             self.finish({"status_code": 400, "result": "Bad Request"})
 
 class DescribeProcessHandler(IPythonHandler):
+    # inputs: algo_id, version
+    # outputs: algo_lst, result (PRE HTML with algo details)
     def get(self):
         # ==================================
         # Part 1: Parse Required Arguments
@@ -1016,35 +1018,22 @@ class DescribeProcessHandler(IPythonHandler):
         logging.debug(params)
 
         # ==================================
-        # Part 2: Build & Send Request
+        # Part 2: Build & Send Request (outsourced to maap-py lib)
         # ==================================
-        headers = {'Content-Type':'application/json'}
-        if 'proxy-ticket' in params.keys():
-            ticket = params.get('proxy-ticket')
-            if not ticket == 'undefined':
-                headers['proxy-ticket'] = ticket
-
         params.pop('proxy-ticket')
         if all(e == '' for e in list(params.values())):
             complete = False
 
-        logging.debug(list(params.values()))
-        logging.debug(complete)
+        # logging.debug(list(params.values()))
+        # logging.debug(complete)
 
+        maap = MAAP()
         # return all algorithms if malformed request
         if complete:
-            url = maap_api_url(self.request.host) +'/mas/algorithm/{algo_id}:{version}'.format(**params)
+            r = maap.describeAlgorithm('{algo_id}:{version}'.format(**params))
         else:
-            url = maap_api_url(self.request.host) +'/mas/algorithm'
+            r = maap.listAlgorithms()
 
-        logging.debug('request sent to {}'.format(url))
-        logging.debug('headers:')
-        logging.debug(headers)
-
-        r = requests.get(
-            url,
-            headers=headers
-        )
         # print(r.status_code)
         # print(r.text)
 

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -441,13 +441,15 @@ class ExecuteHandler(IPythonHandler):
         kwargs = self.args_to_dict()
         maap = MAAP()
         resp = maap.submitJob(**kwargs)
-        if resp['status_cde'] == 200:
+        logger.debug(resp)
+        status_code = resp['http_status_code']
+        if status_code == 200:
             result = 'JobID is {}'.format(resp['job_id'])
-            self.finish({"status_code": resp['status_code'], "result": result})
-        elif resp['status_code'] == 400:
-            self.finish({"status_code": resp['status_code'], "result": resp['result']})
+            self.finish({"status_code": status_code, "result": result})
+        elif status_code == 400:
+            self.finish({"status_code": status_code, "result": resp['result']})
         else:
-            self.finish({"status_code": resp['status_code'], "result": resp['status']})
+            self.finish({"status_code": status_code, "result": resp['status']})
 
 class GetStatusHandler(IPythonHandler):
     # inputs: job_id

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -921,19 +921,21 @@ class DeleteHandler(IPythonHandler):
         # ==================================
         # Part 2: Build & Send Request
         # ==================================
-        url = maap_api_url(self.request.host) +'/dps/job/{job_id}'.format(**params)
-        headers = {'Content-Type':'application/xml'}
-        logging.debug('request sent to {}'.format(url))
-        logging.debug('headers:')
-        logging.debug(headers)
+        # url = maap_api_url(self.request.host) +'/dps/job/{job_id}'.format(**params)
+        # headers = {'Content-Type':'application/xml'}
+        # logging.debug('request sent to {}'.format(url))
+        # logging.debug('headers:')
+        # logging.debug(headers)
         # print(url)
         # print(req_xml)
 
+        maap = MAAP()
         try:
-            r = requests.delete(
-                url,
-                headers=headers
-            )
+            r = maap.deleteJob(params['job_id'])
+            # r = requests.delete(
+            #     url,
+            #     headers=headers
+            # )
 
             # print(r.status_code)
             # print(r.text)

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -731,6 +731,8 @@ class GetMetricsHandler(IPythonHandler):
             self.finish({"status_code": 400, "result": "Bad Request", "metrics":{}})
 
 class GetResultHandler(IPythonHandler):
+    # inputs: job_id
+    # outputs: result (HTML table with product name & locations)
     def get(self):
         # ==================================
         # Part 1: Parse Required Arguments
@@ -750,21 +752,11 @@ class GetResultHandler(IPythonHandler):
         logging.debug(params)
 
         # ==================================
-        # Part 2: Build & Send Request
+        # Part 2: Build & Send Request (outsourced to maap-py lib)
         # ==================================
-        url = maap_api_url(self.request.host) +'/dps/job/{job_id}'.format(**params)
-        headers = {'Content-Type':'application/xml'}
-        logging.debug('request sent to {}'.format(url))
-        logging.debug('headers:')
-        logging.debug(headers)
-        # print(url)
-        # print(req_xml)
-
+        maap = MAAP()
         try:
-            r = requests.get(
-                url,
-                headers=headers
-            )
+            r = maap.getJobResult(params['job_id'])
             # print(r.status_code)
             # print(r.text)
 
@@ -805,14 +797,14 @@ class GetResultHandler(IPythonHandler):
                         p = getProds(prods) #(Output,['url1','url2'])
 
                         url_lst = p[1]
-                        
+
                         ## make the last link clickable
                         lnk = url_lst[-1]
-                        url_lst[-1] = '<a href="{}" target="_blank" style="border-bottom: 1px solid #0000ff; color: #0000ff;">{}</a>'.format(lnk,lnk)
-                        
+                        url_lst[-1] = '<a href="{}" target="_blank" style="border-bottom: 1px solid #0000ff; color: #0000ff;">{}</a>'.format(lnk, lnk)
+
                         urls_str = '•&nbsp'+('<br>•&nbsp;').join(url_lst)
-                        result += '<tr><td>{}: </td><td style="text-align:left">{}</td></tr>'.format('Locations',urls_str)
-                        
+                        result += '<tr><td>{}: </td><td style="text-align:left">{}</td></tr>'.format('Locations', urls_str)
+
                         result += '</tbody>'
                         result += '</table>'
                         logging.debug(result)

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -361,21 +361,23 @@ class PublishAlgorithmHandler(IPythonHandler):
         # Part 2: Build & Send Request
         # ==================================
         # return all algorithms if malformed request
-        headers = {'Content-Type':'application/json'}
-        if 'proxy-ticket' in params.keys():
-            headers['proxy-ticket'] = params.get('proxy-ticket')
+        # headers = {'Content-Type':'application/json'}
+        # if 'proxy-ticket' in params.keys():
+            # headers['proxy-ticket'] = params.get('proxy-ticket')
 
-        logging.debug('headers:')
-        logging.debug(headers)
+        # logging.debug('headers:')
+        # logging.debug(headers)
 
-        url = maap_api_url(self.request.host) +'/mas/publish' 
-        body = {'algo_id': params['algo_id'], 'version': params['version']}
-        logging.debug('request sent to {}'.format(url))
-        r = requests.post(
-            url,
-            headers=headers,
-            data=body
-        )
+        # url = maap_api_url(self.request.host) +'/mas/publish' 
+        # body = {'algo_id': params['algo_id'], 'version': params['version']}
+        # logging.debug('request sent to {}'.format(url))
+        # r = requests.post(
+        #     url,
+        #     headers=headers,
+        #     data=body
+        # )
+        maap = MAAP()
+        r = maap.publishAlgorithm('{algo_id}:{version}'.format(**params))
 
         # print(url)
         # print(r.status_code)

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -1099,38 +1099,20 @@ class ExecuteInputsHandler(IPythonHandler):
         if all(e == '' for e in list(params.values())):
             complete = False
 
-        # print(params)
         params2 = copy.deepcopy(params)
         # params2.pop('identifier')
-        # print(params)
         logging.debug('params are')
         logging.debug(params)
 
         # ==================================
         # Part 2: Build & Send Request
         # ==================================
-        headers = {'Content-Type':'application/json'}
-
-        if 'proxy-ticket' in params.keys():
-            headers['proxy-ticket'] = params.get('proxy-ticket')
-
+        maap = MAAP()
         # return all algorithms if malformed request
         if complete:
-            url = maap_api_url(self.request.host) +'/mas/algorithm/{algo_id}:{version}'.format(**params2) 
+            r = maap.describeAlgorithm('{algo_id}:{version}'.format(**params))
         else:
-            url = maap_api_url(self.request.host) +'/mas/algorithm'
-
-        logging.debug('request sent to {}'.format(url))
-        logging.debug('headers:')
-        logging.debug(headers)
-        
-
-        r = requests.get(
-            url,
-            headers=headers
-        )
-        # print(r.status_code)
-        # print(r.text)
+            r = maap.listAlgorithms()
 
         # ==================================
         # Part 3: Check & Parse Response
@@ -1153,11 +1135,6 @@ class ExecuteInputsHandler(IPythonHandler):
                     for (identifier,typ) in ins_req:
                         result += '{identifier}:\t{typ}\n'.format(identifier=identifier,typ=typ)
                     # print(result)
-
-                    # if len(ins_req) > 0 and result.strip() == '':
-                    # 	result = 'Bad Request\nThe provided parameters were\n\talgo_id:{}\n\tversion:{}\n'.format(params['algo_id'],params['version'])
-                    # 	self.finish({"status_code": 400, "result": result})
-                    # 	return
 
                     logging.debug(params)
                     logging.debug(ins_req)

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -838,20 +838,9 @@ class DismissHandler(IPythonHandler):
         # ==================================
         # Part 2: Build & Send Request
         # ==================================
-        url = maap_api_url(self.request.host) +'/dps/job/revoke/{job_id}'.format(**params)
-        headers = {'Content-Type':'application/xml'}
-        logging.debug('request sent to {}'.format(url))
-        logging.debug('headers:')
-        logging.debug(headers)
-        # print(url)
-        # print(req_xml)
-
+        maap = MAAP()
         try:
-            r = requests.delete(
-                url,
-                headers=headers
-            )
-
+            r = maap.dismissJob(params['job_id'])
             # print(r.status_code)
             # print(r.text)
 
@@ -921,22 +910,9 @@ class DeleteHandler(IPythonHandler):
         # ==================================
         # Part 2: Build & Send Request
         # ==================================
-        # url = maap_api_url(self.request.host) +'/dps/job/{job_id}'.format(**params)
-        # headers = {'Content-Type':'application/xml'}
-        # logging.debug('request sent to {}'.format(url))
-        # logging.debug('headers:')
-        # logging.debug(headers)
-        # print(url)
-        # print(req_xml)
-
         maap = MAAP()
         try:
             r = maap.deleteJob(params['job_id'])
-            # r = requests.delete(
-            #     url,
-            #     headers=headers
-            # )
-
             # print(r.status_code)
             # print(r.text)
 

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -594,6 +594,8 @@ class ExecuteHandler(IPythonHandler):
             self.finish({"status_code": 400, "result": "Bad Request"})
 
 class GetStatusHandler(IPythonHandler):
+    # inputs: job_id
+    # outputs: job_status, result (dialog text of job_status)
     def get(self):
         # ==================================
         # Part 1: Parse Required Arguments
@@ -613,22 +615,11 @@ class GetStatusHandler(IPythonHandler):
         logging.debug(params)
 
         # ==================================
-        # Part 2: Build & Send Request
+        # Part 2: Build & Send Request (outsourced to maap-py lib)
         # ==================================
-        url = maap_api_url(self.request.host) +'/dps/job/{job_id}/status'.format(**params)
-        headers = {'Content-Type':'application/xml'}
-        logging.debug('request sent to {}'.format(url))
-        logging.debug('headers:')
-        logging.debug(headers)
-        # print(url)
-        # print(req_xml)
-
+        maap = MAAP()
         try:
-            r = requests.get(
-                url,
-                headers=headers
-            )
-
+            r = maap.getJobStatus(params['job_id'])
             # print(r.status_code)
             # print(r.text)
 

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -665,6 +665,8 @@ class GetStatusHandler(IPythonHandler):
             self.finish({"status_code": 400, "result": "Bad Request","job_status":''})
 
 class GetMetricsHandler(IPythonHandler):
+    # inputs: job_id
+    # outputs: result (HTML table with metric name & value), metrics (JSON object with k-v as metric-value)
     def get(self):
         # ==================================
         # Part 1: Parse Required Arguments
@@ -684,22 +686,11 @@ class GetMetricsHandler(IPythonHandler):
         logging.debug(params)
 
         # ==================================
-        # Part 2: Build & Send Request
+        # Part 2: Build & Send Request (outsourced to maap-py lib)
         # ==================================
-        url = maap_api_url(self.request.host) +'/dps/job/{job_id}/metrics'.format(**params)
-        headers = {'Content-Type':'application/xml'}
-        logging.debug('request sent to {}'.format(url))
-        logging.debug('headers:')
-        logging.debug(headers)
-        # print(url)
-        # print(req_xml)
-
+        maap = MAAP()
         try:
-            r = requests.get(
-                url,
-                headers=headers
-            )
-
+            r = maap.getJobMetrics(params['job_id'])
             # print(r.status_code)
             # print(r.text)
 

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -156,9 +156,7 @@ class RegisterAlgorithmHandler(IPythonHandler):
         # ==================================
         if params['config_path'] != '':
             # navigate to project directory
-            # proj_path = ('/').join(['/projects']+params['config_path'].split('/')[:-1])
             proj_path = ('/').join(params['config_path'].split('/')[:-1])
-            # proj_path = params['config_path']
             os.chdir(proj_path)
 
             # get git status
@@ -190,15 +188,6 @@ class RegisterAlgorithmHandler(IPythonHandler):
         # Part 3: Build & Send Request
         # ==================================
         json_in_file = WORKDIR+"/submit_jobs/register_inputs.json"
-        url = maap_api_url(self.request.host) + '/mas/algorithm'
-        headers = {'Content-Type':'application/json'}
-
-        if 'proxy-ticket' in params.keys():
-            headers['proxy-ticket'] = params.get('proxy-ticket')
-
-        logging.debug('request sent to {}'.format(url))
-        logging.debug('headers:')
-        logging.debug(headers)
 
         with open(json_in_file) as f:
             ins_json = f.read()
@@ -210,7 +199,7 @@ class RegisterAlgorithmHandler(IPythonHandler):
         ins = ''
         for name in inputs.keys():
             if len(name) > 0:
-                ins += ins_json.format(field_name=name,dl=inputs[name])
+                ins += ins_json.format(field_name=name, dl=inputs[name])
 
         # print(ins)
         # add inputs json to config for template substitution
@@ -220,19 +209,13 @@ class RegisterAlgorithmHandler(IPythonHandler):
             req_json = jso.read()
 
         req_json = req_json.format(**config)
-        logging.debug('request is')
-        logging.debug(req_json)
 
         # ==================================
         # Part 4: Check Response
         # ==================================
+        maap = MAAP()
         try:
-            r = requests.post(
-                url=url,
-                data=req_json,
-                headers=headers
-            )
-            print(r.text)
+            r = maap.registerAlgorithm(req_json)
             if r.status_code == 200:
                 try:
                     # MAAP API response

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -1327,24 +1327,11 @@ class ListJobsHandler(IPythonHandler):
         logging.debug(params)
 
         # ==================================
-        # Part 2: Build & Send Request
+        # Part 2: Build & Send Request (outsourced to maap-py lib)
         # ==================================
-        url = maap_api_url(self.request.host) +'/dps/job/{username}/list'.format(**params)
-        headers = {'Content-Type':'application/xml'}
-
-        if 'proxy-ticket' in params.keys():
-            headers['proxy-ticket'] = params.get('proxy-ticket')
-
-        logging.debug('request sent to {}'.format(url))
-        logging.debug('headers:')
-        logging.debug(headers)
-
+        maap = MAAP()
         try:
-            r = requests.get(
-                url,
-                headers=headers
-            )
-
+            r = maap.listJobs(params['username'])
             # print(r.status_code)
             # print(r.text)
 

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -422,18 +422,10 @@ class GetCapabilitiesHandler(IPythonHandler):
     def get(self):
         # No Required Arguments
         # ==================================
-        # Part 1: Build & Send Request
+        # Part 1: Build & Send Request (outsourced to maap-py lib)
         # ==================================
-        url = maap_api_url(self.request.host) +'/dps/job'
-        headers = {'Content-Type':'application/json'}
-        logging.debug('request sent to {}'.format(url))
-        logging.debug('headers:')
-        logging.debug(headers)
-
-        r = requests.get(
-            url,
-            headers=headers
-        )
+        maap = MAAP()
+        r = maap.getCapabilities()
 
         # ==================================
         # Part 2: Check & Parse Response
@@ -836,7 +828,7 @@ class DismissHandler(IPythonHandler):
         logging.debug(params)
 
         # ==================================
-        # Part 2: Build & Send Request
+        # Part 2: Build & Send Request (outsourced to maap-py lib)
         # ==================================
         maap = MAAP()
         try:
@@ -908,7 +900,7 @@ class DeleteHandler(IPythonHandler):
         logging.debug(params)
 
         # ==================================
-        # Part 2: Build & Send Request
+        # Part 2: Build & Send Request (outsourced to maap-py lib)
         # ==================================
         maap = MAAP()
         try:
@@ -1083,7 +1075,7 @@ class ExecuteInputsHandler(IPythonHandler):
         logging.debug(params)
 
         # ==================================
-        # Part 2: Build & Send Request
+        # Part 2: Build & Send Request (outsourced to maap-py lib)
         # ==================================
         maap = MAAP()
         # return all algorithms if malformed request

--- a/submit_jobs/submit_jobs/handlers.py
+++ b/submit_jobs/submit_jobs/handlers.py
@@ -267,34 +267,19 @@ class DeleteAlgorithmHandler(IPythonHandler):
         if all(e == '' for e in list(params.values())):
             complete = False
 
-        print(complete)
+        # print(complete)
         logging.debug('params are')
         logging.debug(params)
 
         # ==================================
-        # Part 2: Build & Send Request
+        # Part 2: Build & Send Request (outsourced to maap-py lib)
         # ==================================
-        # return all algorithms if malformed request
-        headers = {'Content-Type':'application/json'}
-        logging.debug('headers:')
-        logging.debug(headers)
-
+        maap = MAAP()
         if complete:
-            url = maap_api_url(self.request.host) + '/mas/algorithm/{algo_id}:{version}'.format(**params) 
-            logging.debug('request sent to {}'.format(url))
-            r = requests.delete(
-                url,
-                headers=headers
-            )
+            r = maap.deleteAlgorithm('{algo_id}:{version}'.format(**params))
         else:
-            url = maap_api_url(self.request.host) +'/mas/algorithm'
-            logging.debug('request sent to {}'.format(url))
-            r = requests.get(
-                url,
-                headers=headers
-            )
+            r = maap.listAlgorithms()
 
-        # print(url)
         # print(r.status_code)
         # print(r.text)
 
@@ -333,14 +318,13 @@ class DeleteAlgorithmHandler(IPythonHandler):
             else:
                 self.finish({"status_code": r.status_code, "result": r.reason})
         else:
-            self.finish({"status_code": 400, "result": "Bad Request"})
+            self.finish({"status_code": r.status_code, "result": r.reason})
 
 class PublishAlgorithmHandler(IPythonHandler):
     def get(self):
         # ==================================
         # Part 1: Parse Required Arguments
         # ==================================
-        complete = True
         fields = getFields('publishAlgorithm')
 
         params = {}
@@ -351,35 +335,15 @@ class PublishAlgorithmHandler(IPythonHandler):
             except:
                 complete = False
 
-        if all(e == '' for e in list(params.values())):
-            complete = False
-
         logging.debug('params are')
         logging.debug(params)
 
         # ==================================
-        # Part 2: Build & Send Request
+        # Part 2: Build & Send Request (outsourced to maap-py lib)
         # ==================================
-        # return all algorithms if malformed request
-        # headers = {'Content-Type':'application/json'}
-        # if 'proxy-ticket' in params.keys():
-            # headers['proxy-ticket'] = params.get('proxy-ticket')
-
-        # logging.debug('headers:')
-        # logging.debug(headers)
-
-        # url = maap_api_url(self.request.host) +'/mas/publish' 
-        # body = {'algo_id': params['algo_id'], 'version': params['version']}
-        # logging.debug('request sent to {}'.format(url))
-        # r = requests.post(
-        #     url,
-        #     headers=headers,
-        #     data=body
-        # )
         maap = MAAP()
         r = maap.publishAlgorithm('{algo_id}:{version}'.format(**params))
 
-        # print(url)
         # print(r.status_code)
         # print(r.text)
 


### PR DESCRIPTION
PR replaces direct calls to the MAAP API with a `maap-py` function.  This allows us to respond to changes in the MAAP API in just the `maap-py` library instead of in the `submit_jobs` jupyter extension in addition to the `maap-py` library.