### PR TITLE
Added the inline python code to generate the url prefix

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,16 +1,45 @@
 #!/bin/bash 
-  
-# Reconstruct Che preview url
-THE_MACHINE=''
 
-# Get the Che machine name from either MACHINE_NAME, used by Che v6, or CHE_MACHINE_NAME, used by Che v7 
-if [[ -z "${MACHINE_NAME}" ]]; then
-  THE_MACHINE=`echo $CHE_MACHINE_NAME | tr 'a-z' 'A-Z' | tr '-' '_'`
-else
-  THE_MACHINE="${MACHINE_NAME}"
+# A more robust method of constructing the workspace url prefix
+get_workspace_url_prefix() {
+	python - <<END
+import os
+import requests
+import json
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+namespace = "$1" # 
+svc_host = os.environ.get('KUBERNETES_SERVICE_HOST')
+svc_host_https_port = os.environ.get('KUBERNETES_SERVICE_PORT_HTTPS')
+che_workspace_id = os.environ.get('CHE_WORKSPACE_ID')
+che_machine_name = os.environ.get('CHE_MACHINE_NAME').lower().replace('/', '-')
+
+with open ("/var/run/secrets/kubernetes.io/serviceaccount/token", "r") as t:
+    token=t.read()
+
+headers = {
+    'Authorization': 'Bearer ' + token,
+}
+
+request_string = 'https://' + svc_host + ':' + svc_host_https_port + '/api/v1/namespaces/' + namespace +  '/endpoints/'
+response = requests.get(request_string, headers=headers, verify=False)
+data = response.json()
+
+endpoints = data['items']
+for endpoint in endpoints:
+    if che_machine_name in endpoint['metadata']['name']:
+        if che_workspace_id == endpoint['metadata']['labels']['che.workspace_id']:
+            print("/%s/%s" % (endpoint['metadata']['name'], endpoint['subsets'][0]['ports'][0]['name']))
+            break
+END
+}
+
+PREVIEW_URL=$(get_workspace_url_prefix "$CHE_WORKSPACE_NAMESPACE-che") # Che 7 configuration where the (actual) namespace is "<username>-che"
+if test -z "$PREVIEW_URL" 
+then
+    PREVIEW_URL=$(get_workspace_url_prefix "$CHE_WORKSPACE_ID") # Che 6 configuration fallback where the default namespace is the workspace id
 fi
-
-export PREVIEW_URL=`/usr/bin/printenv | grep $THE_MACHINE | perl -slane 'if(/^(SERVER[^_]+_$mn)_SERVICE_PORT=(\d+)/) { $p=$2; print "/".lc($1=~s/_/-/rg)."/server-".$p; }' -- -mn=$THE_MACHINE | uniq`
 
 # Fix Jupyterlab for Che in `single-host` mode. In `single-host` mode, Che uses URL path prefixes
 # to distinguish workspaces. So for example, `https://<host>/work/space/path/<jupyter endpoints>`. 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,6 +86,10 @@ env | grep _ >> /etc/environment
 export PATH=$PATH:/opt/conda/bin
 cp /root/.bashrc ~/.bash_profile
 
+# Need to fix directory permissions for publickey authentication
+chmod 700 /projects
+mkdir -p /projects/.ssh/
+chmod 700 /projects/.ssh/
 service ssh start
 
 VERSION=$(jupyter lab --version)


### PR DESCRIPTION
I tested the inline python function in ops and pilot ops environment and both produce the correct same url prefix. I haven't built this into an image yet though.