### PR TITLE
Minor changes to the preexisting code that Grace discovered during her internship

### DIFF
--- a/edsc_extension/src/index.ts
+++ b/edsc_extension/src/index.ts
@@ -16,7 +16,6 @@ import { ReadonlyJSONObject } from '@lumino/coreutils';
 
 /** other external imports **/
 import { INotification } from "jupyterlab_toastify";
-import * as $ from "jquery";
 
 /** internal imports **/
 import '../style/index.css';
@@ -128,7 +127,7 @@ function activate(app: JupyterFrontEnd,
 
         xhr.onload = function() {
           if (xhr.status == 200) {
-              let response: any = $.parseJSON(xhr.response);
+              let response: any = JSON.parse(xhr.response);
               response_text = response.query_string;
               if (response_text == "") {
                   response_text = "No results found.";
@@ -168,7 +167,7 @@ function activate(app: JupyterFrontEnd,
 
       xhr.onload = function() {
           if (xhr.status == 200) {
-              let response: any = $.parseJSON(xhr.response);
+              let response: any = JSON.parse(xhr.response);
               let response_text: any = response.granule_urls;
               if (response_text == "") {
                   response_text = "No results found.";

--- a/ipycmc/webpack.config.js
+++ b/ipycmc/webpack.config.js
@@ -8,7 +8,11 @@ cmc_assets = /maap-common-mapping-client\/dist/;
 const rules = [
   { test: /\.ts$/, loader: "ts-loader" },
   { test: /\.js$/, loader: "source-map-loader" },
-  { test: /\.css$/, use: ["style-loader", "css-loader"] }
+  { test: /\.css$/, use: ["style-loader", "css-loader"] },
+  { test: /\.ttf$/, use: ["file-loader"] },
+  { test: /\.woff$/, use: ["file-loader"] },
+  { test: /\.eot$/, use: ["file-loader"] },
+  { test: /\.svg$/, use: ["file-loader"] }
 ];
 
 // Packages that shouldn't be bundled but loaded at runtime


### PR DESCRIPTION
Change 1: In edsc_extension/src/index.ts, the following code was used: `let response: any = $.parseJSON(xhr.response);` This line has become outdated so I replaced the line with `let response: any = JSON.parse(xhr.response);` as Visual Studio code suggested. I also removed the import statement for jquery (`import * as $ from "jquery";`)

Change 2: I frequently encountered problems when running 'npm run build` from the ipycmc readme. Adding in the file loaders to ipycmc/webpack.config.js allowed me to run `npm run build` successfully in both my Windows machine and Windows Subsystem for Linux

Note: These changes don't affect my project, they are just suggestions to preexisting code that I noticed during the course of my 2021 summer internship. 